### PR TITLE
Allow overriding of the 'delayed::job' label

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,18 @@ Only supports the DelayedJob ActiveRecord backend at the moment.
 
         $ bundle
 
-1. Add the following to `config/initializers/peek.rb`:
+3. Add the following to `config/initializers/peek.rb`:
 
     ```ruby
     Peek.into Peek::Views::DelayedJob
     ```
+
+## Configuration
+
+In some cases instead of using the default 'delayed::job' label, you would like
+to use a different label (such as 'DJ'). To achieve this, you can provide it as
+an argument within the initialiser - like so:
+
+```ruby
+Peek.into Peek::Views::DelayedJob, :label => 'DJ'
+```

--- a/app/views/peek/views/_delayed_job.html.erb
+++ b/app/views/peek/views/_delayed_job.html.erb
@@ -1,1 +1,1 @@
-<strong><span data-defer-to="<%= view.defer_key %>-queued">...</span> queued / <span data-defer-to="<%= view.defer_key %>-failed">...</span> failed</strong> delayed::job
+<strong><span data-defer-to="<%= view.defer_key %>-queued">...</span> queued / <span data-defer-to="<%= view.defer_key %>-failed">...</span> failed</strong> <%= view.label %>

--- a/lib/peek/views/delayed_job.rb
+++ b/lib/peek/views/delayed_job.rb
@@ -2,7 +2,7 @@ module Peek
   module Views
     class DelayedJob < View
       def initialize(options = {})
-        @label = options.delete(:label)
+        @label = options[:label]
       end
 
       def label

--- a/lib/peek/views/delayed_job.rb
+++ b/lib/peek/views/delayed_job.rb
@@ -2,6 +2,11 @@ module Peek
   module Views
     class DelayedJob < View
       def initialize(options = {})
+        @label = options.delete(:label)
+      end
+
+      def label
+        @label || 'delayed::job'
       end
 
       def queued_count


### PR DESCRIPTION
This provides the ability to override the label that is used within peek as not
everyone will be wanting to use 'delayed::job'.

Example usage:

```
Peek.into Peek::Views::DelayedJob, :label => 'DJ'
```
